### PR TITLE
tweak debian init script

### DIFF
--- a/debian/mixminion.init
+++ b/debian/mixminion.init
@@ -1,4 +1,13 @@
-#! /bin/sh
+#!/bin/sh
+#
+### BEGIN INIT INFO
+# Provides:             mixminion
+# Required-Start:       $network $local_fs $remote_fs dbus
+# Required-Stop:        $network $local_fs $remote_fs dbus
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    mixminion daemon
+### END INIT INFO
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/bin/mixminion
@@ -6,8 +15,10 @@ NAME=mixminion
 DESC="mixminion daemon"
 PIDFILE=/var/run/$NAME/mixminion.pid
 WAITFORDAEMON=15
-PYTHON=/usr/bin/python2.4
+PYTHON=/usr/bin/python
 PYTHON_BASE=`basename $PYTHON`
+USER=debian-mixminion
+GROUP=debian-mixminion
 
 test -x $DAEMON || exit 0
 
@@ -51,10 +62,10 @@ case "$1" in
 	else
 		echo -n "Starting $DESC: "
 		start-stop-daemon --start --quiet --oknodo \
-			--chuid debian-mixminion:debian-mixminion \
+			--chuid $USER:$GROUP \
 			--pidfile $PIDFILE \
 			--exec $PYTHON \
-			-- /usr/bin/mixminion server-start --daemon --quiet
+			-- $DAEMON server-start --daemon --quiet
 		echo "$NAME."
 	fi
 	;;


### PR DESCRIPTION
- call `python` as `python`, not `python2.4`
- make user and group configurable
- add metadata block (not sure this is perfect, pretty much copy/pasted from somewhere)
- fix hardcoded call to `mixminion` executable where a variable should be used
